### PR TITLE
Rename program options variable for sake of clarity

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -56,15 +56,15 @@ func Run() {
 		cfg.Colors.DirTree.UnselectedItem,
 	)
 
-	var cmds []tea.ProgramOption
+	var opts []tea.ProgramOption
 
-	cmds = append(cmds, tea.WithAltScreen())
+	opts = append(opts, tea.WithAltScreen())
 
 	if cfg.Settings.EnableMouseWheel {
-		cmds = append(cmds, tea.WithMouseAllMotion())
+		opts = append(opts, tea.WithMouseAllMotion())
 	}
 
-	p := tea.NewProgram(m, cmds...)
+	p := tea.NewProgram(m, opts...)
 
 	if err := p.Start(); err != nil {
 		log.Fatal("Failed to start fm", err)


### PR DESCRIPTION
This a tiny styled-based which renames a variable of `[]tea.ProgramOption` from `cmd` to `opt` for sake of clarity.