### PR TITLE
Added information about installation via AUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,23 @@ curl -sfL https://raw.githubusercontent.com/knipferrc/fm/main/install.sh | sh
 go install github.com/knipferrc/fm@latest
 ```
 
+### AUR
+
+Install through the Arch User Repository with your favorite AUR helper.
+There are currently two possible packages:
+
+- [fm-git](https://aur.archlinux.org/packages/fm-git/): Builds the package from the main branch
+
+```sh
+paru -S fm-git
+```
+
+- [fm-bin](https://aur.archlinux.org/packages/fm-bin/): Uses the github release package
+
+```sh
+paru -S fm-bin
+```
+
 ## Features
 
 - Double pane layout


### PR DESCRIPTION
Hey there,
I created a Arch User Repository package [fm-bin](https://aur.archlinux.org/packages/fm-bin/) to install the Release file with a package manager in Arch and thought a note in the readme might help others.

Since there is a second AUR package to build directly from git ([fm-git](https://aur.archlinux.org/packages/fm-git/)), I added this as well.
Feel free to modify as you want.

Best regards
Sam