### PR TITLE
Add arm64 support to the install script for linux/freebsd/openbsd

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,8 +55,11 @@ get_binaries() {
     darwin/386) BINARIES="fm" ;;
     darwin/amd64) BINARIES="fm" ;;
     darwin/arm64) BINARIES="fm" ;;
+    freebsd/arm64) BINARIES="fm" ;;
     linux/386) BINARIES="fm" ;;
+    linux/arm64) BINARIES="fm" ;;
     linux/amd64) BINARIES="fm" ;;
+    openbsd/arm64) BINARIES="fm" ;;
     windows/386) BINARIES="fm" ;;
     windows/amd64) BINARIES="fm" ;;
     *)


### PR DESCRIPTION
Update install.sh for Linux/freebsd/openbsd targets

Tested on an aarch64 Armbian (debian) distro

Addresses https://github.com/knipferrc/fm/issues/100