### PR TITLE
feat: Multi-workspace navigation with dual-pane mode

### DIFF
--- a/internal/tui/helpers.go
+++ b/internal/tui/helpers.go
@@ -73,11 +73,16 @@ func (m *model) updateStatusBar() {
 			statusMessage = m.textinput.View()
 		}
 
+		logoColumn := fmt.Sprintf("%s", m.filetree.GetSelectedItem().FileSize)
+		if m.state == showDualPaneState {
+			logoColumn = "[DUAL] " + logoColumn
+		}
+
 		m.statusbar.SetContent(
 			m.filetree.GetSelectedItem().Name,
 			statusMessage,
 			fmt.Sprintf("%d/%d", m.filetree.Cursor+1, m.filetree.GetTotalItems()),
-			fmt.Sprintf("%s", m.filetree.GetSelectedItem().FileSize),
+			logoColumn,
 		)
 	} else {
 		statusMessage := "Directory is empty"
@@ -86,11 +91,16 @@ func (m *model) updateStatusBar() {
 			statusMessage = m.textinput.View()
 		}
 
+		logoColumn := "FM"
+		if m.state == showDualPaneState {
+			logoColumn = "[DUAL] FM"
+		}
+
 		m.statusbar.SetContent(
 			"N/A",
 			statusMessage,
 			fmt.Sprintf("%d/%d", 0, 0),
-			"FM",
+			logoColumn,
 		)
 	}
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -28,6 +28,7 @@ const (
 	showHelpState
 	showMoveState
 	showCsvState
+	showDualPaneState
 )
 
 type Config struct {
@@ -119,6 +120,7 @@ func New(cfg Config) model {
 			{Key: defaultKeyMap.ForceQuit.Help().Key, Description: defaultKeyMap.ForceQuit.Help().Desc},
 			{Key: defaultKeyMap.Quit.Help().Key, Description: defaultKeyMap.Quit.Help().Desc},
 			{Key: defaultKeyMap.TogglePane.Help().Key, Description: defaultKeyMap.TogglePane.Help().Desc},
+			{Key: defaultKeyMap.ToggleDualPane.Help().Key, Description: defaultKeyMap.ToggleDualPane.Help().Desc},
 			{Key: defaultKeyMap.OpenFile.Help().Key, Description: defaultKeyMap.OpenFile.Help().Desc},
 			{Key: defaultKeyMap.ResetState.Help().Key, Description: defaultKeyMap.ResetState.Help().Desc},
 			{Key: defaultKeyMap.ShowTextInput.Help().Key, Description: defaultKeyMap.ShowTextInput.Help().Desc},

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -67,6 +67,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			cmds = append(cmds, cmd)
 
 			m.textinput.Reset()
+		case key.Matches(msg, m.keyMap.ToggleDualPane):
+			if m.filetree.State == filetree.IdleState && !m.showTextInput {
+				if m.state == showDualPaneState {
+					m.state = idleState
+					m.activePane = 0
+					m.filetree.SetDisabled(false)
+					m.secondaryFiletree.SetDisabled(true)
+					m.disableAllViewports()
+				} else {
+					m.state = showDualPaneState
+					m.disableAllViewports()
+					m.secondaryFiletree.SetDisabled(false)
+					cmds = append(cmds, m.secondaryFiletree.GetDirectoryListingCmd(m.secondaryFiletree.CurrentDirectory))
+				}
+			}
 		case key.Matches(msg, m.keyMap.MoveDirectoryItem):
 			if m.activePane == 0 && m.filetree.State == filetree.IdleState {
 				m.activePane = (m.activePane + 1) % 2
@@ -124,7 +139,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				if m.activePane == 0 {
 					m.filetree.SetDisabled(false)
-					m.secondaryFiletree.SetDisabled(true)
+					m.secondaryFiletree.SetDisabled(m.state != showDualPaneState && m.state != showMoveState)
 					m.disableAllViewports()
 				} else {
 					m.filetree.SetDisabled(true)
@@ -146,6 +161,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.disableAllViewports()
 						m.markdown.SetViewportDisabled(false)
 					case showMoveState:
+						m.secondaryFiletree.SetDisabled(false)
+						m.disableAllViewports()
+					case showDualPaneState:
 						m.secondaryFiletree.SetDisabled(false)
 						m.disableAllViewports()
 					}

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -24,6 +24,8 @@ func (m model) View() string {
 		rightBox = m.secondaryFiletree.View()
 	case showCsvState:
 		rightBox = m.csv.View()
+	case showDualPaneState:
+		rightBox = m.secondaryFiletree.View()
 	}
 
 	return lipgloss.JoinVertical(lipgloss.Top,

--- a/keys/keys.go
+++ b/keys/keys.go
@@ -34,6 +34,7 @@ type KeyMap struct {
 	GotoBottom          key.Binding
 	MoveDirectoryItem   key.Binding
 	RenameDirectoryItem key.Binding
+	ToggleDualPane      key.Binding
 }
 
 func DefaultKeyMap() KeyMap {
@@ -69,5 +70,6 @@ func DefaultKeyMap() KeyMap {
 		CreateFile:          key.NewBinding(key.WithKeys("N"), key.WithHelp("N", "Create new file")),
 		CreateDirectory:     key.NewBinding(key.WithKeys("M"), key.WithHelp("M", "Create new directory")),
 		RenameDirectoryItem: key.NewBinding(key.WithKeys("R"), key.WithHelp("R", "Rename directory items")),
+		ToggleDualPane:      key.NewBinding(key.WithKeys("w"), key.WithHelp("w", "Toggle dual pane mode")),
 	}
 }


### PR DESCRIPTION
Fixes #111

## Changes
- Add dual-pane mode toggled with `w` key
- Add `[DUAL]` indicator in status bar when dual-pane mode is active
- Allow navigating two file manager panes independently using Tab to switch between them

## Test plan
- [ ] Press `w` to toggle dual-pane mode on/off
- [ ] Verify `[DUAL]` indicator appears in status bar when enabled
- [ ] Press Tab to switch between left and right panes
- [ ] Verify each pane navigates independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)